### PR TITLE
Make Bedrock region configurable using AWS_REGION environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Images and videos and PDFs can be provided using the `-a` option, which takes a 
 llm -m nova-lite 'describe this image' -a https://static.simonwillison.net/static/2024/pelicans.jpg
 ```
 
+If you want to use Bedrock in a region other than the default one (us-west-2), set your AWS_REGION environment variable, e.g.
+
+```bash
+export AWS_REGION=eu-west-1
+```
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/llm_bedrock.py
+++ b/llm_bedrock.py
@@ -1,5 +1,6 @@
 import boto3
 import llm
+import os
 import pathlib
 
 MODELS = (
@@ -8,7 +9,7 @@ MODELS = (
     ("us.amazon.nova-lite-v1:0", "nova-lite", True),
     ("us.amazon.nova-pro-v1:0", "nova-pro", True),
 )
-AWS_REGION = "us-west-2"
+AWS_REGION = os.environ["AWS_REGION"] if "AWS_REGION" in os.environ else "us-west-2"
 
 
 @llm.hookimpl


### PR DESCRIPTION
If the AWS_REGION environment variable is set, use it instead of the default region (us-west-2). See also issue #11.